### PR TITLE
Performance Improvement and Robustness

### DIFF
--- a/fitCurves.py
+++ b/fitCurves.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 from numpy import *
 import bezier
+import sys
 
 
 # Fit one (ore more) Bezier curves to a set of points
@@ -148,7 +149,7 @@ def computeMaxError(points, bez, parameters):
     maxDist = 0.0
     splitPoint = len(points)/2
     for i, (point, u) in enumerate(zip(points, parameters)):
-        dist = linalg.norm(bezier.q(bez, u)-point)**2
+        dist = ((bezier.q(bez, u) - point) ** 2).sum(-1)
         if dist > maxDist:
             maxDist = dist
             splitPoint = i
@@ -157,5 +158,8 @@ def computeMaxError(points, bez, parameters):
 
 
 def normalize(v):
-    return v / linalg.norm(v)
+    magnitude = np.sqrt(v.dot(v))
+    if magnitude < sys.float_info.epsilon:
+        return v
+    return v / magnitude
 

--- a/fitCurves.py
+++ b/fitCurves.py
@@ -6,7 +6,6 @@
 from __future__ import print_function
 from numpy import *
 import bezier
-import sys
 
 
 # Fit one (ore more) Bezier curves to a set of points
@@ -158,8 +157,7 @@ def computeMaxError(points, bez, parameters):
 
 
 def normalize(v):
-    magnitude = np.sqrt(v.dot(v))
-    if magnitude < sys.float_info.epsilon:
+    magnitude = sqrt(v.dot(v))
+    if magnitude < finfo(np.float).eps:
         return v
     return v / magnitude
-

--- a/fitCurves.py
+++ b/fitCurves.py
@@ -158,6 +158,6 @@ def computeMaxError(points, bez, parameters):
 
 def normalize(v):
     magnitude = sqrt(v.dot(v))
-    if magnitude < finfo(np.float).eps:
+    if magnitude < finfo(float).eps:
         return v
     return v / magnitude


### PR DESCRIPTION
Added performance improvements for the magnitude.
This [post](https://stackoverflow.com/a/12712725) says:

    %timeit np.apply_along_axis(np.linalg.norm, 1, vectors)
    # Output: 100 loops, best of 3: 2.39 ms per loop
    
    %timeit np.sqrt((vectors ** 2).sum(-1))[..., np.newaxis]
    # Output: 10000 loops, best of 3: 13.8 us per loop

Normalize method now won't fail, if the input has no length.